### PR TITLE
Shortened keys from string(256) to 128 (utf-8 problem)

### DIFF
--- a/redwind/models.py
+++ b/redwind/models.py
@@ -35,7 +35,7 @@ class JsonType(db.TypeDecorator):
 
 
 class Setting(db.Model):
-    key = db.Column(db.String(256), primary_key=True)
+    key = db.Column(db.String(128), primary_key=True)
     name = db.Column(db.String(256))
     value = db.Column(db.Text)
 
@@ -474,7 +474,7 @@ class Tag(db.Model):
 class Nick(db.Model):
     id = db.Column(db.Integer, primary_key=True)
     contact_id = db.Column(db.Integer, db.ForeignKey('contact.id'), index=True)
-    name = db.Column(db.String(256), unique=True)
+    name = db.Column(db.String(128), unique=True)
 
     def __init__(self, **kwargs):
         self.name = kwargs.get('name')


### PR DESCRIPTION
string(256) is too long (at least on a utf-8 mariadb) for a key.
I picked 128 just because it's a nice number. Not sure what the actual _character_ limit (767 :question: _bytes_ or something).
I hope it's not too long for existing keys on existing installations, and that it's enough _practically_.
