### PR TITLE
Fix weird case: mention of post without title?!? (happened)

### DIFF
--- a/redwind/templates/mentions.html
+++ b/redwind/templates/mentions.html
@@ -9,8 +9,10 @@
         on <a href="{{ post.permalink }}">
         {% if post.title %}
           {{ post.title }}
-        {% else %}
+        {% elif post.content %}
           {{post.content | truncate(50) }}
+        {% else %}
+          <em>this</em>
         {% endif %}
         </a>
       </div>


### PR DESCRIPTION
I have no idea why this happens when I mention [this](https://dubiousdod.org/indie/2014/11/repost-of-mondoweiss-net-2014-11-thanksgiving-holiday) (seems to have a title), but with this fix [mentions](https://dubiousdod.org/indie/mentions) don't crash :wink:
