### PR TITLE
Recover from SSL error during tweet's mf2 discovery

### DIFF
--- a/redwind/plugins/twitter.py
+++ b/redwind/plugins/twitter.py
@@ -21,7 +21,7 @@ from bs4 import BeautifulSoup
 from mf2py.parser import Parser as Mf2Parser
 
 from requests_oauthlib import OAuth1Session, OAuth1
-from requests.exceptions import HTTPError
+from requests.exceptions import HTTPError,SSLError
 
 REQUEST_TOKEN_URL = 'https://api.twitter.com/oauth/request_token'
 AUTHORIZE_URL = 'https://api.twitter.com/oauth/authorize'
@@ -330,6 +330,8 @@ def posse_post_discovery(post):
                     return url
         except HTTPError:
             app.logger.exception('Could not fetch original')
+        except SSLError:
+            app.logger.exception('SSL Error')
 
     def find_first_syndicated(originals):
         for original in originals:


### PR DESCRIPTION
In the end, the problem was an SSL error (ccc got a funky cert), and there was no except clause for it.
This fixes the _crash_ reported in #28, but those `During handling of the above exception, another exception occurred` messages are still there (apparently, the crash wasn't because of that). I have a theory what the problem could be, so I'll comment at #28.
