### PR TITLE
Temporary fix for a strange tag cloud bug

### DIFF
--- a/redwind/views.py
+++ b/redwind/views.py
@@ -169,9 +169,12 @@ def tag_cloud():
         query = query.filter(sqlalchemy.sql.expression.not_(Post.draft))
     query = query.group_by(Tag.id).order_by(Tag.name)
     query = query.having(sqlalchemy.func.count(Post.id) >= MIN_TAG_COUNT)
+    tagdict = {}
+    for name, count in query.all():
+        tagdict[name] = tagdict.get(name,0)+count
     tags = [
-        {"name": name, "count": count}
-        for name, count in query.all()
+        {"name": name, "count": tagdict[name]}
+        for name in sorted(tagdict)
     ]
     return render_tags("Tags", tags)
 


### PR DESCRIPTION
Tags appeared several times, with the count split among them
E.g. lol(5) and lol(7), and if you click on lol, you'll see 12 items.

This patch aggregates them (not a heavy operation), but I wonder how this should be done properly.
