### PR TITLE
Escaped article titles in the editor

### DIFF
--- a/redwind/templates/admin/edit_article.jinja2
+++ b/redwind/templates/admin/edit_article.jinja2
@@ -1,7 +1,7 @@
 {% extends "admin/edit_post.jinja2" %}
 {% block content_fields %}
   <div class="form-group">
-    <input placeholder="Title" class="form-control" type="text" name="title" value="{{ post.title or '' }}"/>
+    <input placeholder="Title" class="form-control" type="text" name="title" value="{% if post.title %}{{ post.title|escape }}{% endif %}"/>
   </div>
   <div class="form-group">
     <textarea placeholder="Content" class="form-control" name="content" id="content" rows="8">{{ post.content or '' }}</textarea>


### PR DESCRIPTION
closes #53

This prevents article titles from getting clipped by quotation marks.