### PR TITLE
Improved support for raw reposts shared on Twitter

### DIFF
--- a/redwind/plugins/twitter.py
+++ b/redwind/plugins/twitter.py
@@ -458,7 +458,7 @@ def guess_raw_share_tweet_content(post):
         if context.author_name:
             preview += context.author_name + ': '
 
-        preview += context.content
+        preview += context.content_plain
 
     # if the tweet doesn't get trimmed, put the link on the end anyway
     preview += (' ' if preview else '') + context.permalink


### PR DESCRIPTION
closes #72 

This PR will use a repost's plaintext content rather than its HTML when posting to Twitter if the original post doesn't have a Twitter syndication link. Additionally, the first image in the repost context will be passed along to Twitter.